### PR TITLE
Solve part b of day 1, 2023

### DIFF
--- a/aoc-2023/day-1.ipynb
+++ b/aoc-2023/day-1.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -32,7 +32,7 @@
        "['1abc2', 'pqr3stu8vwx', 'a1b2c3d4e5f', 'treb7uchet']"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -106,25 +106,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "aocd will not submit that answer again. At 2024-12-03 22:22:52.649973-05:00 you've previously submitted 54951 and the server responded with:\n",
       "\u001b[32mThat's the right answer!  You are one gold star closer to restoring snow operations. [Continue to Part Two]\u001b[0m\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<urllib3.response.HTTPResponse at 0x10b0c8760>"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -133,6 +124,134 @@
     "submit(solve_day_1(data.splitlines()), part=\"a\", day=1, year=2023)\n",
     "\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part 2\n",
+    "Your calculation isn't quite right. It looks like some of the digits are actually spelled out with letters: one, two, three, four, five, six, seven, eight, and nine also count as valid \"digits\".\n",
+    "\n",
+    "Equipped with this new information, you now need to find the real first and last digit on each line. For example:\n",
+    "\n",
+    "```\n",
+    "two1nine\n",
+    "eightwothree\n",
+    "abcone2threexyz\n",
+    "xtwone3four\n",
+    "4nineeightseven2\n",
+    "zoneight234\n",
+    "7pqrstsixteen\n",
+    "```\n",
+    "In this example, the calibration values are `29`, `83`, `13`, `24`, `42`, `14`, and `76`. Adding these together produces `281`.\n",
+    "\n",
+    "What is the sum of all of the calibration values?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[29, 83, 13, 24, 42, 14, 76, 18]\n",
+      "sum:  299\n"
+     ]
+    }
+   ],
+   "source": [
+    "def cast_to_digit(string_to_cast: str) -> int:\n",
+    "    if string_to_cast.isdigit():\n",
+    "        return int(string_to_cast)\n",
+    "    return {\n",
+    "        'one': 1,\n",
+    "        'two': 2,\n",
+    "        'three': 3,\n",
+    "        'four': 4,\n",
+    "        'five': 5,\n",
+    "        'six': 6,\n",
+    "        'seven': 7,\n",
+    "        'eight': 8,\n",
+    "        'nine': 9,\n",
+    "        # 'zero': 0,\n",
+    "    }[string_to_cast]\n",
+    "\n",
+    "def extract_first_and_last_digit_string(string_to_extract: str) -> int:\n",
+    "    digit_list = re.findall(r'(?=(\\d|one|two|three|four|five|six|seven|eight|nine))', string_to_extract)\n",
+    "    return cast_to_digit(digit_list[0])*10 + cast_to_digit(digit_list[-1])\n",
+    "\n",
+    "test_data_2 = '''two1nine\n",
+    "eightwothree\n",
+    "abcone2threexyz\n",
+    "xtwone3four\n",
+    "4nineeightseven2\n",
+    "zoneight234\n",
+    "7pqrstsixteen\n",
+    "oneight\n",
+    "'''.splitlines()\n",
+    "\n",
+    "list_data_2 = [extract_first_and_last_digit_string(s) for s in test_data_2]\n",
+    "print(list_data_2)\n",
+    "print('sum: ', sum(list_data_2))\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Answer to the test data is:  55218\n"
+     ]
+    }
+   ],
+   "source": [
+    "def solve_day_1_part_2(input_data_list: list[str]) -> int:\n",
+    "    full_list = [extract_first_and_last_digit_string(s) for s in input_data_list]\n",
+    "    return sum(full_list)\n",
+    "\n",
+    "print('Answer to the test data is: ', solve_day_1_part_2(data.splitlines()))\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mThat's the right answer!  You are one gold star closer to restoring snow operations.You have completed Day 1! You can [Shareon\n",
+      "  Bluesky\n",
+      "Twitter\n",
+      "Mastodon] this victory or [Return to Your Advent Calendar].\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<urllib3.response.HTTPResponse at 0x10b8b6b90>"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "submit(solve_day_1_part_2(data.splitlines()), part=\"2\", day=1, year=2023)"
    ]
   },
   {


### PR DESCRIPTION
The key was the `r'(?=(\d|one|two|three...))'`

The `(?=...)` is a positive lookahead that doesn't consume characters allowing us to find overlapping matches